### PR TITLE
Enhancement/automated deployments

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: '7.4'
           coverage: none
           tools: composer, cs2pr
 
       - name: Install NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: '7.4'
           coverage: none
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Needed to create tags
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '20'
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: '8.2'
 
@@ -71,7 +71,7 @@ jobs:
         run: npm run plugin-zip
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ github.event.inputs.version }}
           name: Release ${{ github.event.inputs.version }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,6 +30,22 @@ jobs:
         with:
           php-version: '8.2'
 
+      - name: Validate version numbers
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          VERSION_NUM="${VERSION#v}"
+          PHP_VERSION=$(grep "^ \* Version:" fraktvalg.php | sed 's/^ \* Version: //' | tr -d '[:space:]')
+          README_VERSION=$(grep "^Stable tag:" readme.txt | sed 's/^Stable tag: //' | tr -d '[:space:]')
+          if [ "$PHP_VERSION" != "$VERSION_NUM" ]; then
+            echo "ERROR: fraktvalg.php Version ($PHP_VERSION) != input ($VERSION_NUM)"
+            exit 1
+          fi
+          if [ "$README_VERSION" != "$VERSION_NUM" ]; then
+            echo "ERROR: readme.txt Stable tag ($README_VERSION) != input ($VERSION_NUM)"
+            exit 1
+          fi
+          echo "Version check passed: $VERSION_NUM"
+
       - name: Create tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,10 +70,21 @@ jobs:
       - name: Package plugin
         run: npm run plugin-zip
 
-      - name: Create draft release
+      - name: Create release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.event.inputs.version }}
           name: Release ${{ github.event.inputs.version }}
-          draft: true
+          draft: false
           files: fraktvalg.zip
+
+      - name: Extract plugin zip to deploy directory
+        run: unzip fraktvalg.zip -d deploy/
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: fraktvalg
+          BUILD_DIR: deploy/fraktvalg

--- a/.github/workflows/deploy-wp-content.yml
+++ b/.github/workflows/deploy-wp-content.yml
@@ -1,0 +1,18 @@
+name: Deploy WordPress.org Content
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-content:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy readme and assets to WordPress.org
+        uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # v2.2.0
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: fraktvalg

--- a/.github/workflows/deploy-wp-content.yml
+++ b/.github/workflows/deploy-wp-content.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Deploy readme and assets to WordPress.org
         uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # v2.2.0

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: '7.4'
           coverage: none


### PR DESCRIPTION
This pull request updates and improves the GitHub Actions workflows for building, releasing, and deploying the project. The main focus is on pinning actions to specific commit SHAs for better security and reliability, adding automated version validation during releases, and introducing a new workflow for deploying WordPress.org plugin content and assets.

**Workflow security and reliability improvements:**

* All uses of `actions/checkout`, `shivammathur/setup-php`, and `actions/setup-node` in `.github/workflows/build-status.yml`, `.github/workflows/coding-standards.yml`, `.github/workflows/create-release.yml`, and `.github/workflows/php-compatibility.yml` have been updated to pin to specific commit SHAs instead of floating version tags. This enhances security and ensures consistent builds. [[1]](diffhunk://#diff-69c23a09d73ad279ab6fafae937489f411691dc4e0f3d0edd9f5b5164d4fb7fdL18-R28) [[2]](diffhunk://#diff-dfd15ae70247bb45f121522ec2e50e5da9aed17e23116d94ec887a4769c44294L17-R20) [[3]](diffhunk://#diff-dfd15ae70247bb45f121522ec2e50e5da9aed17e23116d94ec887a4769c44294L42-R45) [[4]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L19-R48) [[5]](diffhunk://#diff-93c2990b81df932a8ebe1a2f9ac5167d82d3193205e8878d0987d10048061e3fL20-R23)

**Release process enhancements:**

* A new step in `.github/workflows/create-release.yml` validates that the input version matches the version in both `fraktvalg.php` and `readme.txt`, preventing accidental mismatches during release creation.
* The GitHub release step now uses a pinned commit of `softprops/action-gh-release` and creates a published release instead of a draft.
* After packaging, the plugin zip is extracted to a deploy directory, and a new deploy step uses a pinned commit of `10up/action-wordpress-plugin-deploy` to automate deployment to WordPress.org.

**New workflow for WordPress.org content deployment:**

* Introduces `.github/workflows/deploy-wp-content.yml`, a new workflow that deploys the plugin's readme and assets to WordPress.org using `10up/action-wordpress-plugin-asset-update` pinned to a specific commit.